### PR TITLE
Bump jQuery.Validation from 1.11.1 to 1.19.3 in /src/CoMute

### DIFF
--- a/src/CoMute/packages.config
+++ b/src/CoMute/packages.config
@@ -3,7 +3,7 @@
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
-  <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />
+  <package id="jQuery.Validation" version="1.19.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />


### PR DESCRIPTION
Bumps jQuery.Validation from 1.11.1 to 1.19.3.

---
updated-dependencies:
- dependency-name: jQuery.Validation dependency-type: direct:production ...